### PR TITLE
Remove country requirement from checkout validation

### DIFF
--- a/src/components/pages/CheckoutPage.jsx
+++ b/src/components/pages/CheckoutPage.jsx
@@ -263,6 +263,9 @@ const CheckoutPage = () => {
 
     // Validate form
     if (!validateFormData()) {
+      setSubmitError(
+        "Please fill in all required fields correctly before placing your order.",
+      );
       return;
     }
 

--- a/src/components/pages/CheckoutPage.jsx
+++ b/src/components/pages/CheckoutPage.jsx
@@ -103,6 +103,24 @@ const CheckoutPage = () => {
     return validation.isValid;
   };
 
+  // Check if form is ready to submit
+  const isFormReady = () => {
+    const requiredFields = [
+      "firstName",
+      "lastName",
+      "phone",
+      "address",
+      "city",
+    ];
+    const hasAllRequiredFields = requiredFields.every(
+      (field) => formData[field] && formData[field].trim().length > 0,
+    );
+    const hasNoErrors =
+      Object.keys(formErrors).length === 0 ||
+      Object.values(formErrors).every((error) => !error);
+    return hasAllRequiredFields && hasNoErrors;
+  };
+
   // Real-time field validation
   const validateSingleField = (fieldName, value) => {
     const fieldMapping = {
@@ -114,12 +132,21 @@ const CheckoutPage = () => {
       city: "city",
     };
 
+    const customValidationRules = {
+      firstName: checkoutValidationRules.firstName,
+      lastName: checkoutValidationRules.lastName,
+      email: checkoutValidationRules.email,
+      phone: checkoutValidationRules.phone,
+      streetAddress: checkoutValidationRules.streetAddress,
+      city: checkoutValidationRules.city,
+    };
+
     const mappedFieldName = fieldMapping[fieldName];
     if (mappedFieldName) {
       const validation = validateField(
         mappedFieldName,
         value,
-        checkoutValidationRules,
+        customValidationRules,
       );
       if (!validation.isValid) {
         setFormErrors((prev) => ({

--- a/src/components/pages/CheckoutPage.jsx
+++ b/src/components/pages/CheckoutPage.jsx
@@ -76,6 +76,16 @@ const CheckoutPage = () => {
 
   // Enhanced form validation function using utility
   const validateFormData = () => {
+    // Create custom validation rules without the country requirement
+    const customValidationRules = {
+      firstName: checkoutValidationRules.firstName,
+      lastName: checkoutValidationRules.lastName,
+      email: checkoutValidationRules.email,
+      phone: checkoutValidationRules.phone,
+      streetAddress: checkoutValidationRules.streetAddress,
+      city: checkoutValidationRules.city,
+    };
+
     const formDataForValidation = {
       firstName: formData.firstName,
       lastName: formData.lastName,
@@ -87,7 +97,7 @@ const CheckoutPage = () => {
 
     const validation = validateForm(
       formDataForValidation,
-      checkoutValidationRules,
+      customValidationRules,
     );
     setFormErrors(validation.errors);
     return validation.isValid;

--- a/src/components/pages/CheckoutPage.jsx
+++ b/src/components/pages/CheckoutPage.jsx
@@ -616,6 +616,13 @@ const CheckoutPage = () => {
                   {isSubmitting ? "Processing Order..." : "Place Order"}
                 </span>
               </button>
+
+              {/* Form status indicator */}
+              {!isFormReady() && Object.keys(formErrors).length === 0 && (
+                <p className="mt-2 text-sm text-gray-600 text-center">
+                  Please fill in all required fields to place your order
+                </p>
+              )}
             </form>
           </div>
 


### PR DESCRIPTION
This change modifies the checkout form validation to remove the country field requirement.

Changes made:
- Created custom validation rules that exclude the country field from the original checkoutValidationRules
- Updated validateFormData() and validateSingleField() functions to use the custom validation rules instead of the full checkoutValidationRules
- Added isFormReady() function to check if all required fields are filled and have no validation errors
- Enhanced form submission validation with a specific error message when validation fails
- Added a form status indicator that shows a message when required fields are missing

The checkout form now validates firstName, lastName, email, phone, streetAddress, and city fields without requiring a country selection.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c8584e38637a42b8ba51a8e4958ae269/glow-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c8584e38637a42b8ba51a8e4958ae269</projectId>-->
<!--<branchName>glow-haven</branchName>-->