### PR TITLE
Replace inline SVGs with icon components in Navigation

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -135,50 +135,33 @@ const Navigation = ({
 
           {/* Mobile menu button and cart */}
           <div className="md:hidden flex items-center space-x-2">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="8" cy="21" r="1" />
-              <circle cx="19" cy="21" r="1" />
-              <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
-            </svg>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-            >
-              <path d="M4 12h16" />
-              <path d="M4 18h16" />
-              <path d="M4 6h16" />
-            </svg>
+            {/* Mobile Cart Button */}
             <Link
               to="/cart"
               className="relative p-2 text-gray-600 hover:text-blue-600 transition-colors duration-300"
               aria-label="View cart"
-            />
+            >
+              <ShoppingCart className="w-6 h-6" />
+              {cartItems.length > 0 && (
+                <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs w-5 h-5 rounded-full flex items-center justify-center font-bold">
+                  {cartItems.length}
+                </span>
+              )}
+            </Link>
 
+            {/* Mobile Menu Toggle Button */}
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="p-2 text-gray-600 hover:text-blue-600 transition-colors duration-300"
               aria-label="Toggle mobile menu"
               aria-expanded={isMenuOpen}
-            />
+            >
+              {isMenuOpen ? (
+                <X className="w-6 h-6" />
+              ) : (
+                <Menu className="w-6 h-6" />
+              )}
+            </button>
           </div>
         </div>
 


### PR DESCRIPTION
Replace inline SVG elements with imported icon components in the mobile navigation section.

Changes made:
- Replaced inline shopping cart SVG with ShoppingCart component
- Replaced inline hamburger menu SVG with Menu component  
- Added X component for close menu state
- Added cart item count badge display
- Improved button content with proper icon rendering
- Added conditional rendering for menu toggle (Menu/X icons)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e07e91cb96164a779cd6f6847f52d261/nova-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e07e91cb96164a779cd6f6847f52d261</projectId>-->
<!--<branchName>nova-haven</branchName>-->