### PR TITLE
Replace wishlist with share button and use product slugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/king svg white.svg" />
+    <link rel="icon" type="image/svg+xml" href="/kingsvg.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sneakrz King</title>
     <script

--- a/src/components/pages/ProductDetailPage.jsx
+++ b/src/components/pages/ProductDetailPage.jsx
@@ -3,21 +3,22 @@ import { useParams, useNavigate } from "react-router-dom";
 import { Star, Plus, Minus, ShoppingCart, ArrowLeft, Share2 } from "lucide-react";
 import ProductGallery from "../product/ProductGallery.jsx";
 import { useCart } from "../../context/CartContext.jsx";
+import { findProductBySlug } from "../../utils/urlUtils.js";
 
 const ProductDetailPage = ({ products, onAddToCart, loadingStates = {} }) => {
-  const { id } = useParams();
+  const { slug } = useParams();
   const navigate = useNavigate();
   const [selectedSize, setSelectedSize] = useState("");
   const [quantity, setQuantity] = useState(1);
   const [product, setProduct] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Find the product by ID and scroll to top
+  // Find the product by slug and scroll to top
   useEffect(() => {
-    // Scroll to top when component mounts or ID changes
+    // Scroll to top when component mounts or slug changes
     window.scrollTo({ top: 0, behavior: 'smooth' });
 
-    const foundProduct = products.find(p => p.id === parseInt(id));
+    const foundProduct = findProductBySlug(products, slug);
     if (foundProduct) {
       setProduct(foundProduct);
       // Update document title
@@ -35,7 +36,7 @@ const ProductDetailPage = ({ products, onAddToCart, loadingStates = {} }) => {
     return () => {
       document.title = 'Sneakrz King';
     };
-  }, [id, products]);
+  }, [slug, products]);
 
   if (isLoading) {
     return (

--- a/src/components/pages/ProductDetailPage.jsx
+++ b/src/components/pages/ProductDetailPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Star, Plus, Minus, ShoppingCart, ArrowLeft, Share2, Heart } from "lucide-react";
+import { Star, Plus, Minus, ShoppingCart, ArrowLeft, Share2 } from "lucide-react";
 import ProductGallery from "../product/ProductGallery.jsx";
 import { useCart } from "../../context/CartContext.jsx";
 
@@ -300,19 +300,13 @@ const ProductDetailPage = ({ products, onAddToCart, loadingStates = {} }) => {
                 </button>
               </div>
 
-              <div className="flex space-x-2">
-                <button
-                  onClick={handleShare}
-                  className="flex-1 py-3 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
-                >
-                  <Share2 className="w-4 h-4" />
-                  Share
-                </button>
-                <button className="flex-1 py-3 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors flex items-center justify-center gap-2">
-                  <Heart className="w-4 h-4" />
-                  Wishlist
-                </button>
-              </div>
+              <button
+                onClick={handleShare}
+                className="w-full py-3 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+              >
+                <Share2 className="w-4 h-4" />
+                Share
+              </button>
             </div>
 
             {/* Product Description */}

--- a/src/components/pages/ProductDetailPage.jsx
+++ b/src/components/pages/ProductDetailPage.jsx
@@ -104,18 +104,37 @@ const ProductDetailPage = ({ products, onAddToCart, loadingStates = {} }) => {
           url: window.location.href,
         });
       } catch (error) {
-        console.log("Sharing failed:", error);
-        copyToClipboard();
+        // Only fallback to copy if the error isn't from user cancellation
+        if (error.name !== 'AbortError') {
+          console.log("Sharing failed:", error);
+          copyToClipboard();
+        }
       }
     } else {
       copyToClipboard();
     }
   };
 
-  const copyToClipboard = () => {
-    navigator.clipboard.writeText(window.location.href).then(() => {
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
       alert("Product link copied to clipboard!");
-    });
+    } catch (error) {
+      console.log("Copy to clipboard failed:", error);
+      // Fallback for browsers that don't support clipboard API
+      const textArea = document.createElement('textarea');
+      textArea.value = window.location.href;
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      try {
+        document.execCommand('copy');
+        alert("Product link copied to clipboard!");
+      } catch (fallbackError) {
+        alert("Could not copy link. Please copy manually: " + window.location.href);
+      }
+      document.body.removeChild(textArea);
+    }
   };
 
   const isAddToCartLoading = loadingStates[`add-${product.id}`];

--- a/src/components/product/ProductCard.jsx
+++ b/src/components/product/ProductCard.jsx
@@ -123,7 +123,7 @@ const ProductCard = ({
         </div>
 
         {/* Product Name */}
-        <Link to={`/product/${product.id}`}>
+        <Link to={getProductUrl(product)}>
           <h3 className="text-xl font-bold text-gray-900 leading-tight line-clamp-2 hover:text-blue-600 transition-colors cursor-pointer">
             {product.name}
           </h3>

--- a/src/components/product/ProductCard.jsx
+++ b/src/components/product/ProductCard.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Star, Plus, Minus, Eye, ShoppingCart } from "lucide-react";
 import ProductGallery from "./ProductGallery.jsx";
+import { getProductUrl } from "../../utils/urlUtils.js";
 
 // Optimized ProductCard with lazy loading and performance improvements
 const ProductCard = ({
@@ -233,7 +234,7 @@ const ProductCard = ({
         {/* Action Buttons */}
         <div className="flex flex-col space-y-2">
           <Link
-            to={`/product/${product.id}`}
+            to={getProductUrl(product)}
             className="w-full py-3 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
           >
             <Eye className="w-4 h-4" />

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -976,7 +976,7 @@ function App() {
               <Route path="/cart" element={<CartPage />} />
               <Route path="/checkout" element={<CheckoutPage />} />
               <Route
-                path="/product/:id"
+                path="/product/:slug"
                 element={
                   <ProductDetailPage
                     products={products}

--- a/src/utils/urlUtils.js
+++ b/src/utils/urlUtils.js
@@ -1,0 +1,35 @@
+// Utility functions for URL generation and product routing
+
+/**
+ * Generate a URL-friendly slug from product name
+ * @param {string} name - Product name
+ * @returns {string} - URL slug
+ */
+export const generateProductSlug = (name) => {
+  return name
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '') // Remove special characters except spaces and hyphens
+    .replace(/\s+/g, '-') // Replace spaces with hyphens
+    .replace(/-+/g, '-') // Replace multiple hyphens with single hyphen
+    .trim()
+    .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+};
+
+/**
+ * Find product by slug
+ * @param {Array} products - Array of products
+ * @param {string} slug - Product slug
+ * @returns {Object|null} - Found product or null
+ */
+export const findProductBySlug = (products, slug) => {
+  return products.find(product => generateProductSlug(product.name) === slug) || null;
+};
+
+/**
+ * Generate full product URL
+ * @param {Object} product - Product object
+ * @returns {string} - Product URL
+ */
+export const getProductUrl = (product) => {
+  return `/product/${generateProductSlug(product.name)}`;
+};


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR implements two key improvements:
1. Remove the wishlist functionality and replace it with a full-width share button
2. Update the favicon from Vite logo to the king SVG and improve URL structure by using product names instead of IDs in routes

## Code changes
- **Favicon update**: Changed from `/king svg white.svg` to `/kingsvg.svg` in index.html
- **Wishlist removal**: Removed Heart icon import and wishlist button from ProductDetailPage
- **Share button enhancement**: Made share button full-width and improved error handling for clipboard operations
- **URL structure improvement**: 
  - Changed route from `/product/:id` to `/product/:slug`
  - Created new `urlUtils.js` with functions to generate URL-friendly slugs from product names
  - Updated ProductCard and ProductDetailPage to use slug-based routing
  - Products now accessible via `/product/product-name` instead of `/product/5`
- **Enhanced share functionality**: Added better fallback mechanisms for browsers that don't support native sharing or clipboard API

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/78f9818b16d141b18df93f3f532fe0b8/zen-garden)

👀 [Preview Link](https://78f9818b16d141b18df93f3f532fe0b8-zen-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>78f9818b16d141b18df93f3f532fe0b8</projectId>-->
<!--<branchName>zen-garden</branchName>-->