### PR TITLE
Fix size selector to default to first available size

### DIFF
--- a/src/components/pages/ProductDetailPage.jsx
+++ b/src/components/pages/ProductDetailPage.jsx
@@ -25,10 +25,17 @@ const ProductDetailPage = ({ products, onAddToCart, loadingStates = {} }) => {
       // Update document title
       document.title = `${foundProduct.name} - Sneakrz King`;
 
-      // Set default size if available
+      // Set default size to first available size
       if (foundProduct.sizes && foundProduct.sizes.length > 0) {
-        const firstSize = foundProduct.sizes[0];
-        setSelectedSize(typeof firstSize === "object" ? firstSize.value : firstSize);
+        const firstAvailableSize = foundProduct.sizes.find((size) => {
+          return typeof size === "object" ? size.available : true;
+        });
+        if (firstAvailableSize) {
+          const sizeValue = typeof firstAvailableSize === "object"
+            ? firstAvailableSize.value
+            : firstAvailableSize;
+          setSelectedSize(sizeValue);
+        }
       }
     }
     setIsLoading(false);

--- a/src/components/product/ProductCard.jsx
+++ b/src/components/product/ProductCard.jsx
@@ -15,8 +15,14 @@ const ProductCard = ({
   const { isAF1Product } = useCart();
   const [selectedSize, setSelectedSize] = useState(() => {
     if (product.sizes && product.sizes.length > 0) {
-      const firstSize = product.sizes[0];
-      return typeof firstSize === "object" ? firstSize.value : firstSize;
+      const firstAvailableSize = product.sizes.find((size) => {
+        return typeof size === "object" ? size.available : true;
+      });
+      if (firstAvailableSize) {
+        return typeof firstAvailableSize === "object"
+          ? firstAvailableSize.value
+          : firstAvailableSize;
+      }
     }
     return "";
   });


### PR DESCRIPTION
## Purpose
Fix the size selector issue where it was defaulting to the first size in the list regardless of availability. The user reported that size 36 was being selected by default even when unavailable, simply because it was the first element. The goal is to make the selector default to the first available size instead.

## Code changes
- **ProductDetailPage.jsx**: Updated the default size selection logic to find and select the first available size instead of just the first size in the array
- **ProductCard.jsx**: Applied the same fix to ensure consistent behavior across both components
- Added availability checking logic that handles both object and primitive size formats
- Added fallback handling when no available sizes are found

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/0b94cf5c6725477d9e729f723b998fa8/curry-studio)

👀 [Preview Link](https://0b94cf5c6725477d9e729f723b998fa8-curry-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0b94cf5c6725477d9e729f723b998fa8</projectId>-->
<!--<branchName>curry-studio</branchName>-->